### PR TITLE
cmd/elwinator: sample exp segments from namespace

### DIFF
--- a/cmd/elwinator/src/actions/index.js
+++ b/cmd/elwinator/src/actions/index.js
@@ -69,13 +69,15 @@ export const experimentName = (namespace, experiment, name) => ({
  * expermient.
  * @param {string} namespace - The namespace that the experiment is in.
  * @param {string} experiment - The experiment that is being changed.
+ * @param {Array} namespaceSegments - The segments claimed by the namespace.
  * @param {number} numSegments - The number of segments the experiment
  * should have.
  */
-export const experimentNumSegments = (namespace, experiment, numSegments) => ({
+export const experimentNumSegments = (namespace, experiment, namespaceSegments, numSegments) => ({
   type: 'EXPERIMENT_NUM_SEGMENTS',
   namespace,
   experiment,
+  namespaceSegments,
   numSegments,
 });
 

--- a/cmd/elwinator/src/components/Experiment.js
+++ b/cmd/elwinator/src/components/Experiment.js
@@ -19,6 +19,17 @@ const Experiment = ({ ns, exp, experimentNumSegments, experimentPercent }) => {
       }
       return prev - e.numSegments;
     }, 128),
+    namespaceSegments: ns.experiments.reduce((prev, e) => {
+      if (e.name === exp.name) {
+        return prev;
+      }
+      e.segments.forEach((seg, i) => {
+        if (seg === 1) {
+          prev[i] = 1;
+        }
+      });
+      return prev;
+    }, new Array(128).fill(0)),
     redirectOnSubmit: false,
     experimentNumSegments,
   }

--- a/cmd/elwinator/src/components/SegmentInput.js
+++ b/cmd/elwinator/src/components/SegmentInput.js
@@ -5,7 +5,7 @@ import { experimentURL } from '../urls';
 
 const percents = [1, 25, 50, 100];
 
-const SegmentInput = ({ namespaceName, experimentName, numSegments, availableSegments, redirectOnSubmit, experimentNumSegments }) => {
+const SegmentInput = ({ namespaceName, experimentName, namespaceSegments, numSegments, availableSegments, redirectOnSubmit, experimentNumSegments }) => {
   let numSeg;
 
   const radio = percents.map(p => {
@@ -15,7 +15,7 @@ const SegmentInput = ({ namespaceName, experimentName, numSegments, availableSeg
         <input type="radio"
           name="percent"
           checked={ Math.floor((p/100)*availableSegments) === numSegments }
-          onChange={() => experimentNumSegments(namespaceName, experimentName, Math.floor((p/100)*availableSegments))}
+          onChange={() => experimentNumSegments(namespaceName, experimentName, namespaceSegments,  Math.floor((p/100)*availableSegments))}
         /> {p}% of available segments
         </label>
       </div>
@@ -27,7 +27,7 @@ const SegmentInput = ({ namespaceName, experimentName, numSegments, availableSeg
       if (!numSeg.value.trim()) {
         return;
       }
-      experimentNumSegments(namespaceName, experimentName, numSeg.value);
+      experimentNumSegments(namespaceName, experimentName, namespaceSegments, numSeg.value);
       if (!redirectOnSubmit) {
         return;
       }
@@ -43,7 +43,7 @@ const SegmentInput = ({ namespaceName, experimentName, numSegments, availableSeg
         max={availableSegments}
         className="form-control"
         value={numSegments}
-        onChange={(e) => experimentNumSegments(namespaceName, experimentName, e.target.value)}
+        onChange={(e) => experimentNumSegments(namespaceName, experimentName, namespaceSegments, e.target.value)}
         ref={ node => numSeg = node }
       />
       <p className="help-block">The number of segments to use for this experiment</p>
@@ -56,6 +56,7 @@ const SegmentInput = ({ namespaceName, experimentName, numSegments, availableSeg
 SegmentInput.propTypes = {
   namespaceName: PropTypes.string.isRequired,
   experimentName: PropTypes.string.isRequired,
+  namespaceSegments: PropTypes.array.isRequired,
   numSegments: PropTypes.number.isRequired,
   availableSegments: PropTypes.number.isRequired,
   redirectOnSubmit: PropTypes.bool.isRequired,

--- a/cmd/elwinator/src/reducers/experiments.js
+++ b/cmd/elwinator/src/reducers/experiments.js
@@ -1,5 +1,5 @@
 import params from './params';
-import shuffle from '../shuffle';
+import { sample } from '../shuffle';
 
 const experimentInitialState = {
   name: '',
@@ -17,12 +17,7 @@ const experiment = (state = experimentInitialState, action) => {
     return { ...state, name: action.name };
   case 'EXPERIMENT_NUM_SEGMENTS':
     const ns = parseInt(action.numSegments, 10);
-    const ensSegments = new Array(128).fill(0).fill(1, 0, ns);
-    return { ...state, numSegments: ns, segments: shuffle(ensSegments) };
-  case 'EXPERIMENT_PERCENT':
-    const p = Math.floor((parseFloat(action.percent) / 100)*128);
-    const epSegments = new Array(128).fill(0).fill(1, 0, p);
-    return { ...state, numSegments: p, segments: shuffle(epSegments) };
+    return { ...state, numSegments: ns, segments: sample(action.namespaceSegments, action.numSegments) };
   case 'PARAM_NAME':
   case 'ADD_PARAM':
   case 'TOGGLE_WEIGHTED':
@@ -41,7 +36,6 @@ const experiments = (state = [], action) => {
     return [...state, experiment(undefined, action)];
   case 'EXPERIMENT_NAME':
   case 'EXPERIMENT_NUM_SEGMENTS':
-  case 'EXPERIMENT_PERCENT':
   case 'PARAM_NAME':
   case 'ADD_PARAM':
   case 'TOGGLE_WEIGHTED':

--- a/cmd/elwinator/src/reducers/namespaces.js
+++ b/cmd/elwinator/src/reducers/namespaces.js
@@ -18,7 +18,6 @@ const namespace = (state = namespaceInitialState, action) => {
   case 'ADD_EXPERIMENT':
   case 'EXPERIMENT_NAME':
   case 'EXPERIMENT_NUM_SEGMENTS':
-  case 'EXPERIMENT_PERCENT':
   case 'PARAM_NAME':
   case 'ADD_PARAM':
   case 'TOGGLE_WEIGHTED':
@@ -41,7 +40,6 @@ const namespaces = (state = [], action) => {
   case 'ADD_EXPERIMENT':
   case 'EXPERIMENT_NAME':
   case 'EXPERIMENT_NUM_SEGMENTS':
-  case 'EXPERIMENT_PERCENT':
   case 'PARAM_NAME':
   case 'ADD_PARAM':
   case 'TOGGLE_WEIGHTED':

--- a/cmd/elwinator/src/shuffle.js
+++ b/cmd/elwinator/src/shuffle.js
@@ -2,10 +2,25 @@
  * shuffle shuffles an array using fisher-yates algorithm
  * @param {Array} arr - the array to shuffle.
  */
-export default function shuffle(arr) {
+export function shuffle(arr) {
   for (let i = arr.length-1; i > 0; i--) {
     const n = Math.floor(Math.random()*i);
     [arr[i], arr[n]] = [arr[n], arr[i]];
   }
   return arr
+}
+
+export function sample(arr1, num) {
+  const free = arr1.map((seg, i) => {
+    // if the segment is claimed return -1
+    if (seg === 1) {
+      return -1;
+    }
+    // otherwise return the index
+    return i;
+  }).filter(i => i >= 0);
+  shuffle(free);
+  let out = new Array(128).fill(0);
+  free.slice(0, num).forEach(i => out[i] = 1);
+  return out;
 }


### PR DESCRIPTION
experiments segments should not overlap. therefore we compute the
namespace level segments claimed by combining all it's experiment
segments. New experiments are only allowed to sample from unclaimed
segments. This fixes #33.