### PR TITLE
cmd/elwinator: move the conversion funcs to nsconv

### DIFF
--- a/cmd/elwinator/src/components/PublishView.js
+++ b/cmd/elwinator/src/components/PublishView.js
@@ -1,45 +1,9 @@
 import React from 'react';
 
 import { togglePublish, namespacesLoaded } from '../actions';
-import { toNamespace } from '../nsconv';
+import { toNamespace, fromNamespace } from '../nsconv';
 
-function fromSegments(segments) {
-  return btoa(String.fromCharCode.apply(null, segments));
-};
 
-function fromParam(param) {
-  const p = {
-    name: param.name,
-    value: param.isWeighted ? {
-      choices: param.choices,
-      weights: param.weights.map(w => parseInt(w, 10)),
-    } : { choices: param.choices },
-  };
-  return p;
-}
-
-function fromExperiment(experiment) {
-  const e = {
-    name: experiment.name,
-    segments: fromSegments(experiment.segments),
-    params: experiment.params.map(p => fromParam(p)),
-  };
-  return e;
-}
-
-function fromLabels(labels) {
-  return labels.filter(l => l.active)
-  .map(l => l.name);
-}
-
-function fromNamespace(namespace) {
-  const n = {
-    name: namespace.name,
-    labels: fromLabels(namespace.labels),
-    experiments: namespace.experiments.map(e => fromExperiment(e)),
-  }
-  return n;
-}
 
 function createRequest(namespace) {
   return {

--- a/cmd/elwinator/src/nsconv.js
+++ b/cmd/elwinator/src/nsconv.js
@@ -73,3 +73,41 @@ export const toNamespace = ns => {
   experiments = experiments.map(toExperiment);
   return { name, labels, experiments }
 }
+
+const fromSegments = (segments) => {
+  return btoa(String.fromCharCode.apply(null, segments));
+};
+
+const fromParam = (param) => {
+  const p = {
+    name: param.name,
+    value: param.isWeighted ? {
+      choices: param.choices,
+      weights: param.weights.map(w => parseInt(w, 10)),
+    } : { choices: param.choices },
+  };
+  return p;
+}
+
+const fromExperiment (experiment) => {
+  const e = {
+    name: experiment.name,
+    segments: fromSegments(experiment.segments),
+    params: experiment.params.map(p => fromParam(p)),
+  };
+  return e;
+}
+
+const fromLabels = (labels) => {
+  return labels.filter(l => l.active)
+  .map(l => l.name);
+}
+
+export const fromNamespace = (namespace) => {
+  const n = {
+    name: namespace.name,
+    labels: fromLabels(namespace.labels),
+    experiments: namespace.experiments.map(e => fromExperiment(e)),
+  }
+  return n;
+}


### PR DESCRIPTION
clean up the publish view component and extract the functions that can
be used by other components.