### PR TITLE
cmd/elwinator: delete the rootURL links from views

### DIFF
--- a/cmd/elwinator/src/components/NewChoiceView.js
+++ b/cmd/elwinator/src/components/NewChoiceView.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 
 import NavSection from './NavSection';
-import { rootURL, namespaceURL, experimentURL, paramURL } from '../urls';
+import { namespaceURL, experimentURL, paramURL } from '../urls';
 import NewChoice from '../connectors/NewChoice';
 
 const NewChoiceView = ({ params }) => {
@@ -11,7 +11,6 @@ const NewChoiceView = ({ params }) => {
       <div className="row"><h1>Create a new experiment</h1></div>
       <div className="row">
         <NavSection>
-          <Link to={ rootURL() } className="nav-link">Home</Link>
           <Link to={ namespaceURL(params.namespace) } className="nav-link">{params.namespace} - Namespace</Link>
           <Link to={ experimentURL(params.namespace, params.experiment) } className="nav-link">{params.experiment} - Experiment </Link>
           <Link to={ paramURL(params.namespace, params.experiment, params.param) } className="nav-link">{params.param} - Param </Link>

--- a/cmd/elwinator/src/components/NewExperimentView.js
+++ b/cmd/elwinator/src/components/NewExperimentView.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 
 import NavSection from './NavSection';
-import { rootURL, namespaceURL } from '../urls';
+import { namespaceURL } from '../urls';
 import NewExperiment from './NewExperiment';
 
 const NewExperimentView = ({ params }) => {
@@ -11,7 +11,6 @@ const NewExperimentView = ({ params }) => {
       <div className="row"><h1>Create a new experiment</h1></div>
       <div className="row">
         <NavSection>
-          <Link to={ rootURL() } className="nav-link">Home</Link>
           <Link to={ namespaceURL(params.namespace) } className="nav-link">{params.namespace} - Namespace</Link>
         </NavSection>
         <div className="col-sm-9">

--- a/cmd/elwinator/src/components/NewLabelView.js
+++ b/cmd/elwinator/src/components/NewLabelView.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 
 import NavSection from './NavSection';
-import { rootURL, namespaceURL } from '../urls';
+import { namespaceURL } from '../urls';
 import NewLabel from '../connectors/NewLabel';
 
 const NewLabelView = ({ params }) => {
@@ -11,7 +11,6 @@ const NewLabelView = ({ params }) => {
       <div className="row"><h1>Create a new experiment</h1></div>
       <div className="row">
         <NavSection>
-          <Link to={ rootURL() } className="nav-link">Home</Link>
           <Link to={ namespaceURL(params.namespace) } className="nav-link">{params.namespace} - Namespace</Link>
         </NavSection>
         <div className="col-sm-9">

--- a/cmd/elwinator/src/components/NewParamView.js
+++ b/cmd/elwinator/src/components/NewParamView.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 
 import NavSection from './NavSection';
-import { rootURL, namespaceURL, experimentURL } from '../urls';
+import { namespaceURL, experimentURL } from '../urls';
 import NewParam from './NewParam';
 
 const NewParamView = ({ params }) => {
@@ -11,7 +11,6 @@ const NewParamView = ({ params }) => {
       <div className="row"><h1>Create a new experiment</h1></div>
       <div className="row">
         <NavSection>
-          <Link to={ rootURL() } className="nav-link">Home</Link>
           <Link to={ namespaceURL(params.namespace) } className="nav-link">{params.namespace} - Namespace</Link>
           <Link to={ experimentURL(params.namespace, params.experiment) } className="nav-link">{params.experiment} - Experiment </Link>
         </NavSection>


### PR DESCRIPTION
previously i forgot to remove the rootURL links from each view when i
created the NavSection component that automatically added home and back
links. This fixes #53.