### PR TITLE
cmd/elwinator: trim all the line lengths to 100 ch

### DIFF
--- a/cmd/elwinator/src/App.js
+++ b/cmd/elwinator/src/App.js
@@ -11,7 +11,11 @@ const App = ({ namespaceName, params, children }) => {
       <h1>Elwinator</h1>
       <h2>Namespaces</h2>
       <NamespaceList />
-      <Link to={namespaceNewURL()} className="btn btn-default" role="button">Create new namespace</Link>
+      <Link
+        to={namespaceNewURL()}
+        className="btn btn-default"
+        role="button"
+      >Create new namespace</Link>
       <h2>Publish Changes</h2>
       <PublishView />
     </div>

--- a/cmd/elwinator/src/components/Back.js
+++ b/cmd/elwinator/src/components/Back.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { browserHistory } from 'react-router';
 
-const Back = props => <a className="nav-link" onClick={e => { e.preventDefault(); browserHistory.goBack(); }}>Back</a>;
+const Back = props =>
+  <a className="nav-link" onClick={e => {
+    e.preventDefault(); browserHistory.goBack();
+  }}>Back</a>;
 
 export default Back

--- a/cmd/elwinator/src/components/Experiment.js
+++ b/cmd/elwinator/src/components/Experiment.js
@@ -33,7 +33,9 @@ const Experiment = ({ ns, exp, dispatch }) => {
   }
   return (
     <div className="container">
-      <div className="row"><div className="col-sm-9 col-sm-offset-3"><h1>{exp.name}</h1></div></div>
+      <div className="row">
+        <div className="col-sm-9 col-sm-offset-3"><h1>{exp.name}</h1></div>
+      </div>
       <div className="row">
         <NavSection>
           <Link to={namespaceURL(ns.name)} className="nav-link">{ns.name} - Namespace</Link>
@@ -42,10 +44,16 @@ const Experiment = ({ ns, exp, dispatch }) => {
         <div className="col-sm-9">
           <h2>Segments</h2>
           <SegmentInput {...siProps } />
-          <Segment namespaceSegments={siProps.namespaceSegments} experimentSegments={exp.segments} />
+          <Segment
+            namespaceSegments={siProps.namespaceSegments}
+            experimentSegments={exp.segments}
+          />
           <h2>Params</h2>
           <ParamList namespaceName={ns.name} experimentName={exp.name} />
-          <Link to={paramNewURL(ns.name, exp.name)} className="btn btn-default" role="button">Create new param</Link><br />
+          <Link
+            to={paramNewURL(ns.name, exp.name)}
+            className="btn btn-default"
+            role="button">Create new param</Link><br />
           <button className="btn btn-warning" onClick={() => {
             dispatch(experimentDelete(ns.name, exp.name));
             browserHistory.push(namespaceURL(ns.name));

--- a/cmd/elwinator/src/components/ExperimentList.js
+++ b/cmd/elwinator/src/components/ExperimentList.js
@@ -11,7 +11,12 @@ const ExperimentList = ({ namespaceName, experiments, dispatch }) => {
       <td>{i + 1}</td>
       <td><Link to={experimentURL(namespaceName, e.name)}>{e.name}</Link></td>
       <td>{e.params.map(p => p.name).join(', ')}</td>
-      <td><button className="btn btn-default btn-xs" onClick={() => dispatch(experimentDelete(namespaceName, e.name))}>&times;</button></td>
+      <td>
+        <button
+          className="btn btn-default btn-xs"
+          onClick={() => dispatch(experimentDelete(namespaceName, e.name))}
+        >&times;</button>
+      </td>
     </tr>
   );
   return (

--- a/cmd/elwinator/src/components/LabelList.js
+++ b/cmd/elwinator/src/components/LabelList.js
@@ -13,7 +13,10 @@ const LabelList = ({ namespaceName, labels, dispatch }) => {
     });
     return (
     <li key={l.name}>
-      <button className={spanClassName} onClick={() => dispatch(toggleLabel(namespaceName, l.name))}>{l.name}</button>
+      <button
+        className={spanClassName}
+        onClick={() => dispatch(toggleLabel(namespaceName, l.name))}
+       >{l.name}</button>
     </li>
     );
   }

--- a/cmd/elwinator/src/components/Namespace.js
+++ b/cmd/elwinator/src/components/Namespace.js
@@ -35,7 +35,11 @@ const Namespace = ({ ns, dispatch }) => {
           <Segment namespaceSegments={nsSegments} />
           <h2>Experiments</h2>
           <ExperimentList namespaceName={ ns.name } />
-          <Link to={experimentNewURL(ns.name)} className="btn btn-default" role="button">Create new experiment</Link><br />
+          <Link
+            to={experimentNewURL(ns.name)}
+            className="btn btn-default"
+            role="button"
+          >Create new experiment</Link><br />
           <button className="btn btn-warning" onClick={() => {
             dispatch(namespaceDelete(ns.name));
             browserHistory.push(rootURL());

--- a/cmd/elwinator/src/components/NamespaceList.js
+++ b/cmd/elwinator/src/components/NamespaceList.js
@@ -13,7 +13,12 @@ const NamespaceList = ({ namespaces, dispatch }) => {
       <td>{i + 1}</td>
       <td><Link to={namespaceURL(n.name)}>{n.name}</Link></td>
       <td>{n.experiments.map(e => e.name).join(', ')}</td>
-      <td><button className="btn btn-default btn-xs" onClick={() => dispatch(namespaceDelete(n.name))}>&times;</button></td>
+      <td>
+        <button
+          className="btn btn-default btn-xs"
+          onClick={() => dispatch(namespaceDelete(n.name))}
+        >&times;</button>
+      </td>
     </tr>
   )
   return (

--- a/cmd/elwinator/src/components/NewChoice.js
+++ b/cmd/elwinator/src/components/NewChoice.js
@@ -4,7 +4,14 @@ import { browserHistory } from 'react-router';
 import { addChoice, addWeight } from '../actions';
 import { paramURL } from '../urls';
 
-const NewChoice = ({ namespaceName, experimentName, paramName, isWeighted, dispatch, redirectOnSubmit }) => {
+const NewChoice = ({
+  namespaceName,
+  experimentName,
+  paramName,
+  isWeighted,
+  dispatch,
+  redirectOnSubmit
+}) => {
   let choice;
   let weight;
   return (

--- a/cmd/elwinator/src/components/NewChoiceView.js
+++ b/cmd/elwinator/src/components/NewChoiceView.js
@@ -11,9 +11,18 @@ const NewChoiceView = ({ params }) => {
       <div className="row"><h1>Create a new experiment</h1></div>
       <div className="row">
         <NavSection>
-          <Link to={ namespaceURL(params.namespace) } className="nav-link">{params.namespace} - Namespace</Link>
-          <Link to={ experimentURL(params.namespace, params.experiment) } className="nav-link">{params.experiment} - Experiment </Link>
-          <Link to={ paramURL(params.namespace, params.experiment, params.param) } className="nav-link">{params.param} - Param </Link>
+          <Link
+            to={ namespaceURL(params.namespace) }
+            className="nav-link"
+          >{params.namespace} - Namespace</Link>
+          <Link
+            to={ experimentURL(params.namespace, params.experiment) }
+            className="nav-link"
+          >{params.experiment} - Experiment </Link>
+          <Link
+            to={ paramURL(params.namespace, params.experiment, params.param) }
+            className="nav-link"
+          >{params.param} - Param </Link>
         </NavSection>
         <div className="col-sm-9">
           <NewChoice params={params}/>

--- a/cmd/elwinator/src/components/NewExperimentView.js
+++ b/cmd/elwinator/src/components/NewExperimentView.js
@@ -11,7 +11,10 @@ const NewExperimentView = ({ params }) => {
       <div className="row"><h1>Create a new experiment</h1></div>
       <div className="row">
         <NavSection>
-          <Link to={ namespaceURL(params.namespace) } className="nav-link">{params.namespace} - Namespace</Link>
+          <Link
+            to={ namespaceURL(params.namespace) }
+            className="nav-link"
+          >{params.namespace} - Namespace</Link>
         </NavSection>
         <div className="col-sm-9">
           <NewExperiment namespaceName={params.namespace} />

--- a/cmd/elwinator/src/components/NewLabelView.js
+++ b/cmd/elwinator/src/components/NewLabelView.js
@@ -11,7 +11,10 @@ const NewLabelView = ({ params }) => {
       <div className="row"><h1>Create a new experiment</h1></div>
       <div className="row">
         <NavSection>
-          <Link to={ namespaceURL(params.namespace) } className="nav-link">{params.namespace} - Namespace</Link>
+          <Link
+            to={ namespaceURL(params.namespace) }
+            className="nav-link"
+          >{params.namespace} - Namespace</Link>
         </NavSection>
         <div className="col-sm-9">
           <NewLabel params={params}/>

--- a/cmd/elwinator/src/components/NewParamView.js
+++ b/cmd/elwinator/src/components/NewParamView.js
@@ -11,8 +11,14 @@ const NewParamView = ({ params }) => {
       <div className="row"><h1>Create a new experiment</h1></div>
       <div className="row">
         <NavSection>
-          <Link to={ namespaceURL(params.namespace) } className="nav-link">{params.namespace} - Namespace</Link>
-          <Link to={ experimentURL(params.namespace, params.experiment) } className="nav-link">{params.experiment} - Experiment </Link>
+          <Link
+            to={ namespaceURL(params.namespace) }
+            className="nav-link"
+          >{params.namespace} - Namespace</Link>
+          <Link
+            to={ experimentURL(params.namespace, params.experiment) }
+            className="nav-link"
+          >{params.experiment} - Experiment </Link>
         </NavSection>
         <div className="col-sm-9">
           <NewParam namespaceName={params.namespace} experimentName={params.experiment} />

--- a/cmd/elwinator/src/components/Param.js
+++ b/cmd/elwinator/src/components/Param.js
@@ -14,9 +14,18 @@ const Param = ({ namespaceName, experimentName, p, dispatch }) => {
       <div className="row"><div className="col-sm-9 col-sm-offset-3"><h1>{p.name}</h1></div></div>
       <div className="row">
         <NavSection>
-          <Link to={namespaceURL(namespaceName)} className="nav-link">{namespaceName} - Namespace</Link>
-          <Link to={experimentURL(namespaceName, experimentName)} className="nav-link">{experimentName} - Experiment</Link>
-          <Link to={choiceNewURL(namespaceName, experimentName, p.name)} className="nav-link">Create a new choice</Link>
+          <Link
+            to={namespaceURL(namespaceName)}
+            className="nav-link"
+          >{namespaceName} - Namespace</Link>
+          <Link
+            to={experimentURL(namespaceName, experimentName)}
+            className="nav-link"
+          >{experimentName} - Experiment</Link>
+          <Link
+            to={choiceNewURL(namespaceName, experimentName, p.name)}
+            className="nav-link"
+          >Create a new choice</Link>
         </NavSection>
         <div className="col-sm-9">
           <h2>Weight</h2>
@@ -30,7 +39,9 @@ const Param = ({ namespaceName, experimentName, p, dispatch }) => {
                   }}
                   checked={p.isWeighted} /> Weighted choices
               </label>
-              <p className="help-block">If you select this then you will need to add weights to your choices.</p>
+	      <p className="help-block">
+                If you select this then you will need to add weights to your choices.
+              </p>
             </div>
           </form>
           <h2>Choices</h2>

--- a/cmd/elwinator/src/components/PublishView.js
+++ b/cmd/elwinator/src/components/PublishView.js
@@ -68,7 +68,11 @@ const PublishView = ({ namespaces, dispatch }) => {
       });
       Promise.all(requests).then(responses => {
         const headers = new Headers({'Accept': 'application/json'});
-        const req = { method: 'POST', headers: headers, body: JSON.stringify({ environment: "Staging" }) };
+        const req = {
+          method: 'POST',
+          headers: headers,
+          body: JSON.stringify({ environment: "Staging" })
+        };
         const badRequest = (req, resp) =>  ({ err: "bad request", req, resp });
         fetch("/api/v1/all", req)
         .then(resp => {

--- a/cmd/elwinator/src/components/SegmentInput.js
+++ b/cmd/elwinator/src/components/SegmentInput.js
@@ -7,7 +7,15 @@ import { experimentNumSegments } from '../actions';
 
 const percents = [1, 25, 50, 100];
 
-const SegmentInput = ({ namespaceName, experimentName, namespaceSegments, numSegments, availableSegments, redirectOnSubmit, dispatch }) => {
+const SegmentInput = ({
+  namespaceName,
+  experimentName,
+  namespaceSegments,
+  numSegments,
+  availableSegments,
+  redirectOnSubmit,
+  dispatch
+}) => {
   let numSeg;
 
   const radio = percents.map(p => {
@@ -17,7 +25,16 @@ const SegmentInput = ({ namespaceName, experimentName, namespaceSegments, numSeg
         <input type="radio"
           name="percent"
           checked={ Math.floor((p/100)*availableSegments) === numSegments }
-          onChange={() => dispatch(experimentNumSegments(namespaceName, experimentName, namespaceSegments,  Math.floor((p/100)*availableSegments)))}
+          onChange={() => 
+            dispatch(
+              experimentNumSegments(
+                namespaceName,
+                experimentName,
+                namespaceSegments,
+                Math.floor((p/100)*availableSegments)
+              )
+            )
+          }
         /> {p}% of available segments
         </label>
       </div>
@@ -29,7 +46,14 @@ const SegmentInput = ({ namespaceName, experimentName, namespaceSegments, numSeg
       if (!numSeg.value.trim()) {
         return;
       }
-      dispatch(experimentNumSegments(namespaceName, experimentName, namespaceSegments, numSeg.value));
+      dispatch(
+        experimentNumSegments(
+          namespaceName,
+          experimentName,
+          namespaceSegments,
+          numSeg.value
+        )
+      );
       if (!redirectOnSubmit) {
         return;
       }
@@ -45,7 +69,16 @@ const SegmentInput = ({ namespaceName, experimentName, namespaceSegments, numSeg
         max={availableSegments}
         className="form-control"
         value={numSegments}
-        onChange={(e) => dispatch(experimentNumSegments(namespaceName, experimentName, namespaceSegments, e.target.value))}
+        onChange={(e) =>
+          dispatch(
+            experimentNumSegments(
+              namespaceName,
+              experimentName,
+              namespaceSegments,
+              e.target.value
+            )
+          )
+        }
         ref={ node => numSeg = node }
       />
       <p className="help-block">The number of segments to use for this experiment</p>

--- a/cmd/elwinator/src/reducers/experiments.js
+++ b/cmd/elwinator/src/reducers/experiments.js
@@ -16,7 +16,11 @@ const experiment = (state = experimentInitialState, action) => {
     return { ...state, name: action.name };
   case 'EXPERIMENT_NUM_SEGMENTS':
     const ns = parseInt(action.numSegments, 10);
-    return { ...state, numSegments: ns, segments: sample(action.namespaceSegments, action.numSegments) };
+    return {
+      ...state,
+      numSegments: ns,
+      segments: sample(action.namespaceSegments, action.numSegments)
+    };
   case 'PARAM_NAME':
   case 'ADD_PARAM':
   case 'PARAM_DELETE':

--- a/cmd/elwinator/src/urls.js
+++ b/cmd/elwinator/src/urls.js
@@ -39,7 +39,8 @@ export const experimentURL = (n, e) => `/n/${encodeURIComponent(n)}/e/${encodeUR
  * @param {string} n - The namespace name.
  * @param {string} e - The experiment name.
  */
-export const paramNewURL = (n, e) => `/n/${encodeURIComponent(n)}/e/${encodeURIComponent(e)}/p/new`;
+export const paramNewURL = (n, e) =>
+  `/n/${encodeURIComponent(n)}/e/${encodeURIComponent(e)}/p/new`;
 
 /**
  * paramURL is the url for a specified param.
@@ -47,7 +48,8 @@ export const paramNewURL = (n, e) => `/n/${encodeURIComponent(n)}/e/${encodeURIC
  * @param {string} e - The experiment name.
  * @param {string} p - The param name.
  */
-export const paramURL = (n, e, p) => `/n/${encodeURIComponent(n)}/e/${encodeURIComponent(e)}/p/${encodeURIComponent(p)}`;
+export const paramURL = (n, e, p) =>
+  `/n/${encodeURIComponent(n)}/e/${encodeURIComponent(e)}/p/${encodeURIComponent(p)}`;
 
 /**
  * choiceNewURL is the url for creating a new choice.
@@ -55,4 +57,5 @@ export const paramURL = (n, e, p) => `/n/${encodeURIComponent(n)}/e/${encodeURIC
  * @param {string} e - The experiment name.
  * @param {string} p - The param name.
  */
-export const choiceNewURL = (n, e, p) => `/n/${encodeURIComponent(n)}/e/${encodeURIComponent(e)}/p/${encodeURIComponent(p)}/c/new`;
+export const choiceNewURL = (n, e, p) =>
+  `/n/${encodeURIComponent(n)}/e/${encodeURIComponent(e)}/p/${encodeURIComponent(p)}/c/new`;


### PR DESCRIPTION
Trim the line lengths on all the elwinator js files because it's easier to
read.